### PR TITLE
add access-control-allow-origin header

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,11 @@ db = require('./models')
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
 
+app.use((req, res, next) => {
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    next()
+})
+
 app.get('/books', function (req, res, next) {
     db.Book.findAll({ attributes: ['title', 'author', 'isbn'] })
         .then(books => {


### PR DESCRIPTION
## 変更点
### Access-Control-Allow-Origin ヘッダーの追加
ヘッダーを設定して、異なるオリジンからAPIにアクセスできるようにしました。