### PR TITLE
Server/return book

### DIFF
--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -172,5 +172,37 @@ describe('test to /users', () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  test('return book', async () => {
+    const book = await books.create('sample');
+    const email = 'foo@bar.com';
+    const password = 'password';
+    const user = await users.create(email, password);
+    const token = await login(email, password);
+
+    const loan = await loans.create(book.id, user.id);
+
+    const res = await request(app)
+        .delete(`/users/${user.id}/loans/${loan.id}`)
+        .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  test('return not existing book', async () => {
+    const book = await books.create('sample');
+    const email = 'foo@bar.com';
+    const password = 'password';
+    const user = await users.create(email, password);
+    const token = await login(email, password);
+
+    const loan = await loans.create(book.id, user.id);
+
+    const res = await request(app)
+        .delete(`/users/${user.id}/loans/${loan.id + 1}`)
+        .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toBe(404);
+  });
 });
 

--- a/server/reference/syskenlibrary.v0.1.yaml
+++ b/server/reference/syskenlibrary.v0.1.yaml
@@ -167,7 +167,7 @@ paths:
         name: id
         in: path
         required: true
-        description: ''
+        description: ユーザーのId、meを利用して自分を表すこともできる
     get:
       summary: get user data
       tags: []
@@ -220,17 +220,17 @@ paths:
                     loans: []
         '401':
           description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples: {}
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                example-1:
+                  value:
+                    error:
+                      message: 他の人のアカウントで操作することはできません
       operationId: get-users-id
       description: ユーザーのデータを取得する
       security:
@@ -243,7 +243,7 @@ paths:
         name: id
         in: path
         required: true
-        description: ''
+        description: ユーザーのId、meを利用して自分を表すこともできる
     post:
       summary: borrow a book
       operationId: post-users-id-loans
@@ -261,12 +261,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                example-1:
+                  value:
+                    error:
+                      message: 指定された本は存在しません
+        '401':
+          description: Unauthorized
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                example-1:
+                  value:
+                    error:
+                      message: 他の人のアカウントで操作することはできません
       description: 本のIdを指定して本を借りる
       requestBody:
         content:
@@ -284,6 +296,55 @@ paths:
                 value:
                   bookId: 1
         description: 本の借りるための情報
+      security:
+        - bearerAuth: []
+  '/users/{userId}/loans/{loanId}':
+    parameters:
+      - schema:
+          type: string
+          pattern: '(me|[0-9]+)'
+        name: userId
+        in: path
+        required: true
+        description: ユーザーのId、meを利用して自分を表すこともできる
+      - schema:
+          type: number
+        name: loanId
+        in: path
+        required: true
+        description: 貸出情報のId
+    delete:
+      summary: return book
+      operationId: delete-users-userId-loans-loanId
+      responses:
+        '204':
+          description: No Content
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                example-1:
+                  value:
+                    error:
+                      message: 他の人のアカウントで操作することはできません
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                example-1:
+                  value:
+                    error:
+                      message: 指定された貸出情報は存在しません
+      description: 貸出Idを指定して本を返却する
+      parameters: []
       security:
         - bearerAuth: []
 components:

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -41,15 +41,20 @@ router.delete('/', async (req, res) => {
   return res.status(204).end();
 });
 
-router.get('/:userId', auth, async (req, res) => {
+const checkUserId = (req, res, next) => {
   if (req.params.userId != 'me' &&
     req.params.userId != req.body.userId) {
     return res.status(403).send({
       error: {
-        message: '他の人のデータを見ることはできません',
+        message: '他の人のアカウントで操作することはできません',
       },
     });
+  } else {
+    next();
   }
+};
+
+router.get('/:userId', auth, checkUserId, async (req, res) => {
   const userId = req.body.userId;
   const foundUser = await users.findById(userId);
 
@@ -58,16 +63,7 @@ router.get('/:userId', auth, async (req, res) => {
 
 router.post('/:userId/loans', [
   check('bookId').isInt(),
-], validate, auth, async (req, res) => {
-  if (req.params.userId != 'me' &&
-    req.params.userId != req.body.userId) {
-    return res.status(403).send({
-      error: {
-        message: '他の人のアカウントで本を借りることはできません',
-      },
-    });
-  }
-
+], validate, auth, checkUserId, async (req, res) => {
   const bookId = req.body.bookId;
   const userId = req.body.userId;
   const book = await books.findById(bookId);

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -91,4 +91,17 @@ router.post('/:userId/loans', [
       .end();
 });
 
+router.delete('/:userId/loans/:loanId', auth, checkUserId, async (req, res) => {
+  const deleted = await loans.deleteById(req.params.loanId);
+  if (deleted) {
+    return res.status(204).end();
+  } else {
+    return res.status(404).send({
+      error: {
+        message: '指定された貸出情報は存在しません',
+      },
+    });
+  }
+});
+
 module.exports = router;

--- a/server/utils/loans.js
+++ b/server/utils/loans.js
@@ -6,3 +6,15 @@ exports.create = async (bookId, userId) => {
     userId: userId,
   });
 };
+
+exports.deleteById = async (loanId) => {
+  const destroyedNum = await loanModel.destroy({
+    where: {id: loanId},
+  });
+
+  if (destroyedNum < 1) {
+    return false;
+  } else {
+    return true;
+  }
+};


### PR DESCRIPTION
#29
## 新たに実装したこと
### 本を返すAPIの追加
ユーザーIdと貸出Idを指定して本を返却するAPIを追加
`DELETE /users/:userId/loans/:loanId`
詳しい使い方はドキュメントを参照してください

## 変更点
### 同一の処理をミドルウェアとして共通化
他人が不正に操作していないかを検証する処理を複数書いていたので、ミドルウェアとして共通化した